### PR TITLE
投稿ステータスが「publish」になったときのみtootするよう修正

### DIFF
--- a/mastodon-for-wp.php
+++ b/mastodon-for-wp.php
@@ -147,5 +147,14 @@ function toot_published_post_for_mastodon($post_id){
 	}
 }
 
-add_action('publish_post', 'toot_published_post_for_mastodon');
+/* tootの是非をpostステータスの遷移で判断する */
+function on_transition_post_status($new_status, $old_status, $post){
+	if ($post->post_type === 'post' && $new_status === 'publish') {
+		if ($old_status !== 'private' && $old_status !== 'publish') {
+			toot_published_post_for_mastodon($post->ID);
+		}
+	}
+}
+
+add_action('transition_post_status', 'on_transition_post_status', 10, 3);
 ?>


### PR DESCRIPTION
従来の実装では、投稿済みの記事を再編集するたびにtootするようになっていたので、投稿のステータスが「publish」に変化したときだけtootするように修正してみました。また、運用を考えて、tootする記事の種類を「post」に限定しています。